### PR TITLE
Fix segfault on CS:GO

### DIFF
--- a/clientlistener.cpp
+++ b/clientlistener.cpp
@@ -63,10 +63,10 @@ ClientListener::ClientListener()
  * @param maxlength    Maximum length of error buffer.
  * @return             True to allow client, false to reject.
  */
-bool ClientListener::InterceptClientConnect(int client, char *error, size_t maxlength)
+void ClientListener::OnClientConnected(int client)
 {
 	if (m_IsHooked)
-		return true;
+		return;
 
 	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(client));
 
@@ -85,9 +85,6 @@ bool ClientListener::InterceptClientConnect(int client, char *error, size_t maxl
 
 		m_IsHooked = true;
 	}
-
-	/* Allow to connect */
-	return true;
 }
 
 

--- a/clientlistener.h
+++ b/clientlistener.h
@@ -36,15 +36,8 @@ class ClientListener : public IClientListener
 {
 public:
 	ClientListener();
-	/**
-	 * Called when a client requests connection.
-	 *
-	 * @param client       Index of the client.
-	 * @param error        Error buffer for a disconnect reason.
-	 * @param maxlength    Maximum length of error buffer.
-	 * @return             True to allow client, false to reject.
-	 */
-	virtual bool InterceptClientConnect(int client, char *error, size_t maxlength);
+
+	virtual void OnClientConnected(int client);
 	void Shutdown();
 
 public:


### PR DESCRIPTION
This PR fixes a segfault what caused when client connects.
Accelerator links for example:
- https://crash.limetech.org/kawxx5gwm4pi
- https://crash.limetech.org/vomtry65ryfs

This error caused by invalid pointer to `INetChannel`. It looks like in `InterceptClientConnect` engine doesn't have valid pointer for player net info at this moment.